### PR TITLE
disable clap suggestions, as they're applying to script arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ suppress-cargo-output = ["chan"]
 
 [dependencies]
 chan = { version = "0.1", optional = true }
-clap = "2.33"
+clap = { version = "2.33", default-features = false, features = ["color", "vec_map"] }
 env_logger = "0.6"
 pulldown-cmark = "0.5"
 lazy_static = "1"


### PR DESCRIPTION
Consider a script named 'nohelp.rs':

```rust
#! /home/jrfondren/.cargo/bin/cargo-eval --

fn main() {
    println!("{}", std::env::args().nth(1)
             .unwrap_or("no arg".to_string()));
}
```

This script is intended to just print its first argument, but unfortunately it silently has many invalid arguments due to clap's suggestions feature:

```bash
$ ./nohelp.rs 'this is ok'
this is ok
$ ./nohelp.rs help
error: The subcommand 'help' wasn't recognized
        Did you mean 'help'?

If you believe you received this message in error, try re-running with 'cargo eval -- help'

USAGE:
    cargo eval [FLAGS OPTIONS] [--] <script> <args>...

For more information try --help
$ ./nohelp.rs help-people.helpful.com
error: The subcommand 'help-people.helpful.com' wasn't recognized
        Did you mean 'help'?

If you believe you received this message in error, try re-running with 'cargo eval -- help-people.helpful.com'

USAGE:
    cargo eval [FLAGS OPTIONS] [--] <script> <args>...

For more information try --help
$ ./nohelp.rs hello
error: The subcommand 'hello' wasn't recognized
        Did you mean 'help'?

If you believe you received this message in error, try re-running with 'cargo eval -- hello'

USAGE:
    cargo eval [FLAGS OPTIONS] [--] <script> <args>...

For more information try --help
```

This PR disables that. Note that, even with 'suggestions' disabled, something like the unfortunate #! there is required, as 'help' and other arguments can still get snatched out of the arguments intended for a script:

```rust
#! /usr/bin/env cargo-eval

fn main() {
    println!("{}", std::env::args().nth(1)
             .unwrap_or("no arg".to_string()));
}
```
and as used:
```
$ ./nohelp.rs help
cargo-eval 0.1.0
Compiles and runs “Cargoified Rust scripts”.

USAGE:
    cargo eval [FLAGS OPTIONS] [--] <script> <args>
...
$ ./nohelp.rs --please no
error: Found argument '--please' which wasn't expected, or isn't valid in this context

USAGE:
    cargo eval [FLAGS OPTIONS] [--] <script> <args>...

For more information try --help
```